### PR TITLE
Add basic mts-esp support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "libs/JUCE"]
 	path = libs/JUCE
 	url = https://github.com/juce-framework/JUCE.git
+[submodule "libs/MTS-ESP"]
+	path = libs/MTS-ESP
+	url = https://github.com/ODDSound/MTS-ESP.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ if(MSVC)
 endif()
 
 add_subdirectory(libs/JUCE)
+# OddSound doesn't have a cmake so...
+add_library(mts-esp-client STATIC libs/MTS-ESP/Client/libMTSClient.cpp)
+target_include_directories(mts-esp-client PUBLIC libs/MTS-ESP/Client)
+
+
 
 set(plugin_formats
     # Standalone
@@ -105,6 +110,7 @@ target_link_libraries(${PROJECT_NAME}
         juce::juce_graphics
         juce::juce_gui_basics
         juce::juce_audio_utils
+        mts-esp-client
     PUBLIC
         juce::juce_recommended_config_flags
         juce::juce_recommended_lto_flags

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -14,6 +14,7 @@
 #include "dsp/Limiter.h"
 #include "dsp/Comb.h"
 #include "dsp/Resonator.h"
+#include "libMTSClient.h"
 
 struct MIDIMsg {
     int offset;
@@ -38,6 +39,7 @@ public:
     int last_b_partials = -1;
     int currentProgram = -1;
     std::atomic<float> rmsValue { 0.0f };
+    MTSClient *mtsClientPtr;
 
     //==============================================================================
     RipplerXAudioProcessor();
@@ -105,6 +107,8 @@ private:
     int nvoice = 0; // next voice to use
     Comb comb{};
     Limiter limiter{};
+    
+
 
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (RipplerXAudioProcessor)

--- a/Source/dsp/Voice.cpp
+++ b/Source/dsp/Voice.cpp
@@ -32,20 +32,27 @@ std::array<std::array<double, 64>, 9> Voice::aModels = {{
 }};
 std::array<std::array<double, 64>, 9> Voice::bModels = aModels;
 
-double Voice::note2freq(int _note) 
+double Voice::note2freq(int _note, MTSClient *mts)
 {
-	return 440 * pow(2.0, (_note - 69) / 12.0); 
+    if (mts == nullptr)
+    {
+        return 440 * pow(2.0, (_note - 69) / 12.0);
+    }
+    else
+    {
+        return MTS_NoteToFrequency(mts, _note, -1);
+    }
 }
 
 // Triggers mallet and noise generator
-void Voice::trigger(double srate, int _note, double _vel, double malletFreq)
+void Voice::trigger(double srate, int _note, double _vel, double malletFreq, MTSClient *mts)
 {
 	resA.clear();
 	resB.clear();
 	note = _note;
 	isRelease = false;
 	vel = _vel;
-	freq = note2freq(note);
+	freq = note2freq(note, mts);
 	mallet.trigger(srate, malletFreq);
 	noise.attack(1.0);
 	if (resA.on) resA.activate();

--- a/Source/dsp/Voice.h
+++ b/Source/dsp/Voice.h
@@ -10,6 +10,7 @@
 #include "Noise.h"
 #include "Resonator.h"
 #include "tuple"
+#include "libMTSClient.h"
 
 class Voice
 {
@@ -27,8 +28,8 @@ public:
 	void static recalcMembrane(bool resA, double ratio);
 	void static recalcPlate(bool resA, double ratio);
 
-	double note2freq(int _note);
-	void trigger(double srate, int _note, double vel, double malletFreq);
+	double note2freq(int _note, MTSClient *mts);
+	void trigger(double srate, int _note, double vel, double malletFreq, MTSClient *mts);
 	void release();
 	void clear();
 	void setPitch(double a_coarse, double b_coarse, double a_fine, double b_fine);


### PR DESCRIPTION
- Add MTS-ESP submodule 
- Modify top cmake to link it
- Add a libMTS pointer member to the processor and register/deregister in ctor/dtor
- Modify the note2freq function to take that pointer and if valid, use it for the note to frequency calculation

That's all she wrote! There is more finesse that could be added later (displaying current scale name, ignoring MTS for a particular instance etc) if you want. But this basic implementation goes a long way! 